### PR TITLE
fix json: restriction exc value range as array

### DIFF
--- a/lib/fslib/json/jsonIO.cc
+++ b/lib/fslib/json/jsonIO.cc
@@ -38,6 +38,16 @@ std::map<const char *, enum disir_restriction_type, cmp_str> attribute_disir_res
     {"RANGE"          , DISIR_RESTRICTION_EXC_VALUE_RANGE},
     {"NUMERIC"        , DISIR_RESTRICTION_EXC_VALUE_NUMERIC}};
 
+//! Map holding string representation of json valuetypes
+std::map<Json::ValueType, const char *> json_type_stringified  = {
+    {Json::intValue    , "integer"},
+    {Json::realValue   , "float"},
+    {Json::booleanValue , "boolean"},
+    {Json::stringValue , "string"},
+    {Json::arrayValue  , "array"},
+    {Json::nullValue   , "null"},
+    {Json::objectValue , "object"}};
+
 JsonIO::JsonIO (struct disir_instance *disir)
 {
     m_disir = disir;
@@ -187,3 +197,15 @@ attribute_key_to_disir_restriction (const char *type)
     }
 }
 
+const char *
+json_valuetype_stringify (Json::ValueType type)
+{
+    try
+    {
+        return json_type_stringified.at (type);
+    }
+    catch (std::out_of_range e)
+    {
+        return "unknown";
+    }
+}

--- a/lib/fslib/json/json_serialize_mold.cc
+++ b/lib/fslib/json/json_serialize_mold.cc
@@ -308,13 +308,13 @@ MoldWriter::serialize_restrictions (struct disir_context *context, Json::Value& 
 
             if (value_type == DISIR_VALUE_TYPE_FLOAT)
             {
-                current_restriction[ATTRIBUTE_KEY_VALUE_MIN] = min;
-                current_restriction[ATTRIBUTE_KEY_VALUE_MAX] = max;
+                current_restriction[ATTRIBUTE_KEY_VALUE].append (min);
+                current_restriction[ATTRIBUTE_KEY_VALUE].append (max);
             }
             else
             {
-                current_restriction[ATTRIBUTE_KEY_VALUE_MIN] = (Json::Int64)min;
-                current_restriction[ATTRIBUTE_KEY_VALUE_MAX] = (Json::Int64)max;
+                current_restriction[ATTRIBUTE_KEY_VALUE].append ((Json::Int64)min);
+                current_restriction[ATTRIBUTE_KEY_VALUE].append ((Json::Int64)max);
             }
 
             break;

--- a/lib/include/json/dplugin_json.h
+++ b/lib/include/json/dplugin_json.h
@@ -14,8 +14,6 @@
 #define ATTRIBUTE_KEY_DEFAULTS "defaults"
 #define ATTRIBUTE_KEY_MOLD "mold"
 #define ATTRIBUTE_KEY_VALUE "value"
-#define ATTRIBUTE_KEY_VALUE_MIN "value_min"
-#define ATTRIBUTE_KEY_VALUE_MAX "value_max"
 #define ATTRIBUTE_KEY_TYPE "type"
 #define ATTRIBUTE_KEY_CONFIG "config"
 #define ATTRIBUTE_KEY_RESTRICTIONS "restrictions"

--- a/lib/include/json/dplugin_json.h
+++ b/lib/include/json/dplugin_json.h
@@ -39,6 +39,10 @@ enum disir_restriction_type attribute_key_to_disir_restriction (const char *type
 
 enum disir_status assert_json_value_type (Json::Value& value, Json::ValueType type);
 
+//! Get the string representation of a json ValueType
+//! return "unknown" if called with invalid type
+const char * json_valuetype_stringify (Json::ValueType type);
+
 
 namespace dio
 {

--- a/test/plugins/json/unserialize_mold_test.cc
+++ b/test/plugins/json/unserialize_mold_test.cc
@@ -287,11 +287,11 @@ TEST_F (UnMarshallMoldTest, invalid_context_on_absent_restriction_value)
                                         "No restriction value present");
 }
 
-TEST_F (UnMarshallMoldTest, invalid_context_on_absent_restriction_value_min)
+TEST_F (UnMarshallMoldTest, invalid_context_on_wrong_restriction_value_range_type)
 {
     ASSERT_NO_THROW (
         Json::Value& restrictions = json_mold["mold"]["float"]["restrictions"];
-        restrictions[0]["value_min"] = Json::nullValue;
+        restrictions[0]["value"] = 1;
     );
 
     status = reader->unserialize (json_writer.writeOrdered (json_mold), &mold);
@@ -301,14 +301,14 @@ TEST_F (UnMarshallMoldTest, invalid_context_on_absent_restriction_value_min)
     ASSERT_INVALID_CONTEXT_COUNT (mold, 2);
     ASSERT_INVALID_CONTEXT_EXIST (mold, NULL, "MOLD", NULL);
     ASSERT_INVALID_CONTEXT_EXIST (mold, "float", "KEYVAL",
-                                        "No restriction value_min present");
+                                        "restriction range value field should be array");
 }
 
-TEST_F (UnMarshallMoldTest, invalid_context_on_absent_restriction_value_max)
+TEST_F (UnMarshallMoldTest, invalid_context_on_wrong_range_value_count)
 {
     ASSERT_NO_THROW (
         Json::Value& restrictions = json_mold["mold"]["float"]["restrictions"];
-        restrictions[0]["value_max"] = Json::nullValue;
+        restrictions[0]["value"].append (1);
     );
 
     status = reader->unserialize (json_writer.writeOrdered (json_mold), &mold);
@@ -318,7 +318,48 @@ TEST_F (UnMarshallMoldTest, invalid_context_on_absent_restriction_value_max)
     ASSERT_INVALID_CONTEXT_COUNT (mold, 2);
     ASSERT_INVALID_CONTEXT_EXIST (mold, NULL, "MOLD", NULL);
     ASSERT_INVALID_CONTEXT_EXIST (mold, "float", "KEYVAL",
-                                        "No restriction value_max present");
+                                        "restriction range value field should have 2 values"\
+                                        ", got 3");
+}
+
+TEST_F (UnMarshallMoldTest, invalid_context_on_wrong_range_value_type)
+{
+    ASSERT_NO_THROW (
+        Json::Value& restrictions = json_mold["mold"]["float"]["restrictions"];
+        restrictions[0]["value"] = Json::arrayValue;
+        restrictions[0]["value"].append ("1");
+        restrictions[0]["value"].append ("2");
+    );
+
+    status = reader->unserialize (json_writer.writeOrdered (json_mold), &mold);
+    ASSERT_STATUS (DISIR_STATUS_INVALID_CONTEXT, status);
+
+
+    ASSERT_INVALID_CONTEXT_COUNT (mold, 2);
+    ASSERT_INVALID_CONTEXT_EXIST (mold, NULL, "MOLD", NULL);
+    ASSERT_INVALID_CONTEXT_EXIST (mold, "float", "KEYVAL",
+                                        "wrong type for value range - got string, expected"\
+                                        " integer or float");
+}
+
+TEST_F (UnMarshallMoldTest, invalid_context_on_value_range_min_larger_than_max)
+{
+    ASSERT_NO_THROW (
+        Json::Value& restrictions = json_mold["mold"]["float"]["restrictions"];
+        restrictions[0]["value"] = Json::arrayValue;
+        restrictions[0]["value"].append (10.1);
+        restrictions[0]["value"].append (1.2);
+    );
+
+    status = reader->unserialize (json_writer.writeOrdered (json_mold), &mold);
+    ASSERT_STATUS (DISIR_STATUS_INVALID_CONTEXT, status);
+
+
+    ASSERT_INVALID_CONTEXT_COUNT (mold, 2);
+    ASSERT_INVALID_CONTEXT_EXIST (mold, NULL, "MOLD", NULL);
+    ASSERT_INVALID_CONTEXT_EXIST (mold, "float", "KEYVAL",
+                                        "restriction value range should have min < max ("\
+                                        "10.1, 1.2)");
 }
 
 TEST_F (UnMarshallMoldTest, invalid_context_on_absent_restriction_value_min_type)


### PR DESCRIPTION
store restriction value range as array
with key 'value' instead of value_min/max.

"value" = [1, 2]