### PR TITLE
fix lib: Fix dx_diff_report_add string buffer realloc

### DIFF
--- a/lib/compare.c
+++ b/lib/compare.c
@@ -112,7 +112,10 @@ dx_diff_report_add (struct disir_diff_report *report, const char *fmt, ...)
     va_start (args, fmt);
     do
     {
-        ret = vsnprintf (report->dr_diff_string[i], n, fmt, args);
+        va_list args_copy;
+        va_copy (args_copy, args);
+        ret = vsnprintf (report->dr_diff_string[i], n, fmt, args_copy);
+        va_end (args_copy);
         if (ret < 0)
         {
             // Encoding error.
@@ -122,8 +125,8 @@ dx_diff_report_add (struct disir_diff_report *report, const char *fmt, ...)
         else if (ret >= n)
         {
             // Insufficient space.
-            n *= 2;
-            moved = realloc (report->dr_diff_string, n);
+            n = ret + sizeof ('\0');
+            moved = realloc (report->dr_diff_string[i], n);
             if (moved)
             {
                 report->dr_diff_string[i] = moved;


### PR DESCRIPTION
These changes reallocates the correct buffer after a truncated vsnprintf
string. They also optimize the reallocated size, and supply a copy of
the va_args to vsnprintf in order reuse it and avoid undefined behavior:

>  As [vsnprintf] invoke the va_arg macro, the value of ap after the
>  return is unspecified. [`man 3p vfprintf`]

#### Refactor proposal
Note that an alternative (and possible improvement) to the current allocation scheme here would be to refactor from:
```
s = malloc(128)
nchar = vsnprintf(s, 128, ...)
s = realloc(nchar + 1, s)
vsnprintf(s, nchar + 1, ...)
```
to:
```
nchar = vsnprintf(NULL, 128, ...)
s = malloc(nchar + 1)
vsnprintf(s, nchar + 1, ...)
```
then there will never be any need for the reallocation, and the strings are always allocated as small as possible.