### PR TITLE
fix lib: Zero initialize config structure reference during import

### DIFF
--- a/lib/disir_import.c
+++ b/lib/disir_import.c
@@ -235,7 +235,7 @@ dx_resolve_config_import_status (struct disir_instance *instance, const char *co
 {
     enum disir_status status;
     struct disir_mold *mold = NULL;
-    struct disir_config *config_imported;
+    struct disir_config *config_imported = NULL;
     char buf[500];
 
     status = verify_mold_support (instance, import, &mold);


### PR DESCRIPTION
During archive imports entries that could not be read properly would be
recorded as failed with an uninitialized reference to the read config
entry. Upon finalization these references would be presumed allocated,
and would crash the application when it tried to free them.